### PR TITLE
Bitbucket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The `vsm-sbom-booster`is a prototype to centralize & automate ([CycloneDX](https://cyclonedx.org/capabilities/sbom/)) SBOM generation. This helps alleviate impediments with the tedious CI/CD-based approach to amend hundreds of CI/CD pipelines and asking engineers to do yet another task.
 
-The prototype is based on the open-source project [**ORT**](https://github.com/oss-review-toolkit/ort), but entails added capabilities to interact both with Git providers APIs (currently only GitHub Cloud & GitHub Enterprise) and automatic upload of SBOMs to your VSM workspace.
+The prototype is based on the open-source project [**ORT**](https://github.com/oss-review-toolkit/ort), but entails added capabilities to interact both with Git providers APIs (currently only GitHub Cloud, GitHub Enterprise, GitLab Cloud, GitLab Self-Hosted, & BitBucket Cloud) and automatic upload of SBOMs to your VSM workspace.
 
 The prototype only needs access to your repositories to do its job.
 
@@ -42,6 +42,21 @@ docker run --pull=always --rm \
            leanixacrpublic.azurecr.io/vsm-sbom-booster
 ```
 
+BitBucket:
+```console
+docker run --pull=always --rm \
+           -v /var/run/docker.sock:/var/run/docker.sock \
+           -v <temp-folder-to-be-used-for-storing-data>:/tempDir \
+           -e MOUNTED_VOLUME='<temp-folder-to-be-used-for-storing-data>' \
+           -e LEANIX_HOST='<leanix-workspace-host>' \
+           -e LEANIX_TOKEN='<leanix-technical-user-token>' \
+           -e GIT_PROVIDER='BITBUCKET' \
+           -e BITBUCKET_KEY='<bitbucket-key>' \
+           -e BITBUCKET_SECRET='<bitbucket-secret>' \
+           -e BITBUCKET_WORKSPACE='<bitbucket-workspace>' \
+           leanixacrpublic.azurecr.io/vsm-sbom-booster
+```
+
 2. After a while your mapping inbox should be receiving new discovery items. These will need to be mapped by you once (see our [user documentation](https://docs-vsm.leanix.net/docs/discover-automate#create-your-service-baseline)).
 
 ### Environment Variables
@@ -51,9 +66,9 @@ The first `-v` param is needed as the setup is a docker-in-docker setup and will
 
 The second `-v` param is the path to temporary folder that the `vsm-sbom-booster`will use to temporarily clone the projects to attempt to generate the SBOM. e.g. `~/output/temp`. Docker should have Read/Write access on this folder.
 
-`MOUNTED_VOLUME`: this is the same as the second `-v` param. It's required as the container needs an explicit env variable to do its job.
+`MOUNTED_VOLUME`: This is the same as the second `-v` param. It's required as the container needs an explicit env variable to do its job.
 
-`CONCURRENCY_FACTOR`(optional): the number of parallel jobs `vsm-sbom-booster` will use to generate SBOMs. Note: increasing this number will come at higher compute costs. Default: 3
+`CONCURRENCY_FACTOR`(optional): The number of parallel jobs `vsm-sbom-booster` will use to generate SBOMs. Note: increasing this number will come at higher compute costs. Default: 3
 
 #### LeanIX configs
 
@@ -63,9 +78,9 @@ The second `-v` param is the path to temporary folder that the `vsm-sbom-booster
 
 #### [Discovery API data](https://docs-vsm.leanix.net/reference/discovery_service)
 
-`SOURCE_TYPE` (optional): this will the source system from where you're scanning. This is used in the mapping inbox to understand where discovered data originated from. Default: `vsm-sbom-booster`
+`SOURCE_TYPE` (optional): This will the source system from where you're scanning. This is used in the mapping inbox to understand where discovered data originated from. Default: `vsm-sbom-booster`
 
-`SOURCE_INSTANCE`(optional): individual instance within the source system e.g. prod or org entity within the source system. This is used in the mapping inbox to understand where discovered data originated from. Default: GitHub Org or GitLab Group + Sub Groups
+`SOURCE_INSTANCE`(optional): Individual instance within the source system e.g. prod or org entity within the source system. This is used in the mapping inbox to understand where discovered data originated from. Default: GitHub Org or GitLab Group + Sub Groups
 
 #### GIT
 
@@ -75,18 +90,25 @@ The second `-v` param is the path to temporary folder that the `vsm-sbom-booster
 
 `GITHUB_TOKEN`: The [Personal Access Token](https://github.com/leanix/vsm-github-broker#personal-access-token) with `read:org` scope. 
 
-`GITHUB_ORGANIZATION`: the GitHub organization name which `vsm-sbom-booster`shall scan and try to generate the SBOMs for.
+`GITHUB_ORGANIZATION`: The GitHub organization name which `vsm-sbom-booster` shall scan and try to generate the SBOMs for.
 
-`GITHUB_API_HOST` (optional): if you want to connect the `vsm-sbom-booster`with GitHub Enterprise you will need to provide the host where the GitHub GraphQL API is exposed. e.g. For `https://ghe.domain.com` you would provide `ghe.domain.com`
+`GITHUB_API_HOST` (optional): if you want to connect the `vsm-sbom-booster` with GitHub Enterprise you will need to provide the host where the GitHub GraphQL API is exposed. e.g. For `https://ghe.domain.com` you would provide `ghe.domain.com`
 
 #### GITLAB (only if `GIT_PROVIDER` is `GITLAB`)
 
 `GITLAB_TOKEN`: The Personal Access Token with API read permissions.
 
-`GITLAB_GROUP`: the GitLab group name which `vsm-sbom-booster`shall scan and try to generate the SBOMs for.
+`GITLAB_GROUP`: The GitLab group name which `vsm-sbom-booster` shall scan and try to generate the SBOMs for.
 
-`GITLAB_API_HOST` (optional): if you want to connect the `vsm-sbom-booster`with GitLab self-hosted you will need to provide the host where the GitLab GraphQL API is exposed. e.g. For `https://gl.domain.com` you would provide `gl.domain.com`
+`GITLAB_API_HOST` (optional): if you want to connect the `vsm-sbom-booster` with GitLab self-hosted you will need to provide the host where the GitLab GraphQL API is exposed. e.g. For `https://gl.domain.com` you would provide `gl.domain.com`
 
+#### BITBUCKET (only if `GIT_PROVIDER` is `BITBUCKET`)
+
+`BITBUCKET_KEY`: The key to an [OAuth Consumer](https://support.atlassian.com/bitbucket-cloud/docs/integrate-another-application-through-oauth/) with "Private Consumer" enabled and the READ:REPOSITORY permission.
+
+`BITBUCKET_SECRET`: The secret to an [OAuth Consumer](https://support.atlassian.com/bitbucket-cloud/docs/integrate-another-application-through-oauth/) with "Private Consumer" enabled and the READ:REPOSITORY permission.
+
+`BITBUCKET_WORKSPACE`: The BitBucket Workspace name which `vsm-sbom-booster` shall scan and try to generate the SBOMs for.
 
 ## Technical Notes
 ![Technical Architecture](/vsm-sbom-booster.png)

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/VsmSbomBoosterApplication.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/VsmSbomBoosterApplication.kt
@@ -52,7 +52,6 @@ class VsmSbomBoosterApplication(
         summaryReportService.appendRecord("GIT_PROVIDER: ${propertiesConfiguration.gitProvider.uppercase()}\n")
 
         val (credentials, repositories) = getRepositories()
-        gotRepositories = true
 
         logger.info("Discovered ${repositories.size} repositories to process.")
 
@@ -65,6 +64,7 @@ class VsmSbomBoosterApplication(
                 credentials.token,
                 it
             )
+            gotRepositories = true
         }
     }
 

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/VsmSbomBoosterApplication.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/VsmSbomBoosterApplication.kt
@@ -30,6 +30,7 @@ class VsmSbomBoosterApplication(
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(VsmSbomBoosterApplication::class.java)
         val counter: AtomicInteger = AtomicInteger(0)
+        var gotRepositories: Boolean = false
     }
 
     override fun run(vararg args: String?) {
@@ -51,6 +52,7 @@ class VsmSbomBoosterApplication(
         summaryReportService.appendRecord("GIT_PROVIDER: ${propertiesConfiguration.gitProvider.uppercase()}\n")
 
         val (credentials, repositories) = getRepositories()
+        gotRepositories = true
 
         logger.info("Discovered ${repositories.size} repositories to process.")
 

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/VsmSbomBoosterApplication.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/VsmSbomBoosterApplication.kt
@@ -30,7 +30,6 @@ class VsmSbomBoosterApplication(
     companion object {
         private val logger: Logger = LoggerFactory.getLogger(VsmSbomBoosterApplication::class.java)
         val counter: AtomicInteger = AtomicInteger(0)
-        var gotRepositories: Boolean = false
     }
 
     override fun run(vararg args: String?) {
@@ -64,7 +63,6 @@ class VsmSbomBoosterApplication(
                 credentials.token,
                 it
             )
-            gotRepositories = true
         }
     }
 

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/configuration/PropertiesConfiguration.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/configuration/PropertiesConfiguration.kt
@@ -39,7 +39,12 @@ data class PropertiesConfiguration(
     @field:NotBlank
     val gitlabApiHost: String,
     val gitlabToken: String,
-    val gitlabGroup: String
+    val gitlabGroup: String,
+
+    // BITBUCKET
+    val bitbucketKey: String,
+    val bitbucketSecret: String,
+    val bitbucketWorkspace: String
 ) {
     val githubGraphqlApiUrl: String
         get() = "https://$githubApiHost/graphql"

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/BitBucketAuthResponse.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/BitBucketAuthResponse.kt
@@ -1,0 +1,10 @@
+package net.leanix.vsm.sbomBooster.domain
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class BitBucketAuthResponse(
+    @JsonProperty("access_token")
+    val accessToken: String,
+)

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/BitBucketRepositoriesResponse.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/BitBucketRepositoriesResponse.kt
@@ -1,0 +1,42 @@
+package net.leanix.vsm.sbomBooster.domain
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class BitBucketRepositoriesResponse(
+    @JsonProperty("next")
+    val next: String?,
+    @JsonProperty("page")
+    val page: Int,
+    @JsonProperty("pagelen")
+    val pageLen: Int,
+    @JsonProperty("size")
+    val size: Int,
+    @JsonProperty("values")
+    val values: List<BitBucketRepository>
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class BitBucketRepository(
+    @JsonProperty("full_name")
+    val fullName: String,
+    @JsonProperty("name")
+    val name: String,
+    @JsonProperty("links")
+    val links: BitBucketRepositoryLinks,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class BitBucketRepositoryLinks(
+    @JsonProperty("clone")
+    val clone: List<BitBucketLink>,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class BitBucketLink(
+    @JsonProperty("name")
+    val name: String?,
+    @JsonProperty("href")
+    val href: String
+)

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/BitBucketRepositoriesResponse.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/BitBucketRepositoriesResponse.kt
@@ -25,6 +25,8 @@ data class BitBucketRepository(
     val name: String,
     @JsonProperty("links")
     val links: BitBucketRepositoryLinks,
+    @JsonProperty("uuid")
+    val uuid: String
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/GitCredentials.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/GitCredentials.kt
@@ -1,0 +1,3 @@
+package net.leanix.vsm.sbomBooster.domain
+
+data class GitCredentials(val username: String, val token: String)

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/Repository.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/Repository.kt
@@ -4,5 +4,6 @@ data class Repository(
     val cloneUrl: String,
     val sourceType: String,
     val sourceInstance: String,
-    val name: String
+    val name: String,
+    val repoId: String
 )

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/VsmDiscoveryItem.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/domain/VsmDiscoveryItem.kt
@@ -5,5 +5,6 @@ data class VsmDiscoveryItem(
     val downloadedFolder: String,
     val sourceType: String,
     val sourceInstance: String,
-    val name: String
+    val name: String,
+    val repoId: String
 )

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/BitBucketApiService.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/BitBucketApiService.kt
@@ -57,6 +57,9 @@ class BitBucketApiService(
         )
         val bbRepositoriesResponse = responseEntity.body?.values ?: emptyList()
 
+        logger.info("HTTP Response Code: ${responseEntity.statusCode}")
+        logger.info("Repos on page: ${bbRepositoriesResponse.size}")
+
         val repositories = mutableListOf<Repository>()
         for (bbRepo in bbRepositoriesResponse) {
             val cloneUrl =
@@ -81,6 +84,8 @@ class BitBucketApiService(
             repositories.addAll(bbRepos)
         }
 
+        logger.info("Running Repo Count: ${repositories.size}")
+
         return repositories.toList()
     }
 
@@ -104,7 +109,6 @@ class BitBucketApiService(
         )
 
         val accessToken = responseEntity.body?.accessToken
-        logger.info("Access token: $accessToken")
 
         return accessToken
     }

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/BitBucketApiService.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/BitBucketApiService.kt
@@ -1,0 +1,110 @@
+package net.leanix.vsm.sbomBooster.service
+
+import net.leanix.vsm.sbomBooster.configuration.PropertiesConfiguration
+import net.leanix.vsm.sbomBooster.domain.BitBucketAuthResponse
+import net.leanix.vsm.sbomBooster.domain.BitBucketRepositoriesResponse
+import net.leanix.vsm.sbomBooster.domain.GitProviderApiService
+import net.leanix.vsm.sbomBooster.domain.Repository
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Service
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import org.springframework.web.client.RestTemplate
+import java.util.*
+
+@Service
+class BitBucketApiService(
+    private val propertiesConfiguration: PropertiesConfiguration
+) : GitProviderApiService {
+
+    companion object {
+        val logger: Logger = LoggerFactory.getLogger(BitBucketApiService::class.java)
+    }
+
+    override fun getUsername(token: String?): String? {
+        return propertiesConfiguration.bitbucketWorkspace
+    }
+
+    override fun getRepositories(token: String?, organization: String): List<Repository> {
+        val bearerToken = authenticate(token)
+
+        return getPaginatedRepositories(bearerToken, organization, null)
+    }
+
+    fun getPaginatedRepositories(bearerToken: String?, organization: String, pageUrl: String?): List<Repository> {
+
+        val restTemplate = RestTemplate()
+        val headers = HttpHeaders()
+
+        headers.set("Authorization", "Bearer $bearerToken")
+        val httpEntity: HttpEntity<*> = HttpEntity<MultiValueMap<String, String>>(headers)
+
+        val url: String = if (pageUrl !== null)
+            pageUrl
+        else
+            "https://api.bitbucket.org/2.0/repositories/$organization"
+
+        val responseEntity = restTemplate.exchange(
+            url, HttpMethod.GET, httpEntity,
+            BitBucketRepositoriesResponse::class.java
+        )
+
+        val bbRepositoriesResponse = responseEntity.body!!.values
+
+        val repositories = mutableListOf<Repository>()
+        for (bbRepo in bbRepositoriesResponse) {
+            // Finds the http clone URL and removes the username from it
+            val cloneUrl =
+                bbRepo.links.clone.firstOrNull { it.name == "https" }?.href?.replaceFirst("[^/]+@".toRegex(), "")
+
+            // Figure out what sourceInstance to use
+            val sourceInstance: String = if (propertiesConfiguration.sourceInstance == "")
+                propertiesConfiguration.bitbucketWorkspace
+            else
+                propertiesConfiguration.sourceInstance
+
+            repositories.add(
+                Repository(
+                    cloneUrl ?: "",
+                    propertiesConfiguration.sourceType,
+                    sourceInstance,
+                    bbRepo.name
+                )
+            )
+        }
+
+        if (responseEntity.body!!.next !== null && responseEntity.body!!.next !== "") {
+            val bbRepos = getPaginatedRepositories(bearerToken, organization, responseEntity.body!!.next)
+            repositories.addAll(bbRepos)
+        }
+
+        return repositories.toList()
+    }
+
+    fun authenticate(token: String?): String? {
+
+        val restTemplate = RestTemplate()
+        val headers = HttpHeaders()
+
+        val encodedAuth = Base64.getEncoder().encodeToString(token?.toByteArray())
+        headers.contentType = MediaType.APPLICATION_FORM_URLENCODED
+        headers.set("Authorization", "Basic $encodedAuth")
+
+        val requestBody: MultiValueMap<String, String> = LinkedMultiValueMap()
+        requestBody.add("grant_type", "client_credentials")
+
+        val httpEntity: HttpEntity<*> = HttpEntity<MultiValueMap<String, String>>(requestBody, headers)
+
+        val responseEntity = restTemplate.postForEntity(
+            "https://bitbucket.org/site/oauth2/access_token", httpEntity,
+            BitBucketAuthResponse::class.java
+        )
+
+        return responseEntity.body!!.accessToken
+    }
+}

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/BitBucketApiService.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/BitBucketApiService.kt
@@ -31,7 +31,6 @@ class BitBucketApiService(
 
     override fun getRepositories(token: String?, organization: String): List<Repository> {
         val bearerToken = authenticate(token)
-        logger.info("Bearer token: $bearerToken")
 
         return getPaginatedRepositories(bearerToken, organization, null)
     }

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/BitBucketApiService.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/BitBucketApiService.kt
@@ -48,16 +48,12 @@ class BitBucketApiService(
             HttpEntity(headers)
 
         val url = pageUrl ?: "https://api.bitbucket.org/2.0/repositories/$organization"
-        logger.info("API URL: $url")
 
         val responseEntity = restTemplate.exchange(
             url, HttpMethod.GET, httpEntity,
             BitBucketRepositoriesResponse::class.java
         )
         val bbRepositoriesResponse = responseEntity.body?.values ?: emptyList()
-
-        logger.info("HTTP Response Code: ${responseEntity.statusCode}")
-        logger.info("Repos on page: ${bbRepositoriesResponse.size}")
 
         val repositories = mutableListOf<Repository>()
         for (bbRepo in bbRepositoriesResponse) {
@@ -83,8 +79,6 @@ class BitBucketApiService(
             repositories.addAll(bbRepos)
         }
 
-        logger.info("Running Repo Count: ${repositories.size}")
-
         return repositories.toList()
     }
 
@@ -107,8 +101,6 @@ class BitBucketApiService(
             BitBucketAuthResponse::class.java
         )
 
-        val accessToken = responseEntity.body?.accessToken
-
-        return accessToken
+        return responseEntity.body?.accessToken
     }
 }

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/BitBucketApiService.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/BitBucketApiService.kt
@@ -5,7 +5,6 @@ import net.leanix.vsm.sbomBooster.domain.BitBucketAuthResponse
 import net.leanix.vsm.sbomBooster.domain.BitBucketRepositoriesResponse
 import net.leanix.vsm.sbomBooster.domain.GitProviderApiService
 import net.leanix.vsm.sbomBooster.domain.Repository
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpEntity
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpMethod
@@ -20,10 +19,6 @@ import java.util.*
 class BitBucketApiService(
     private val propertiesConfiguration: PropertiesConfiguration
 ) : GitProviderApiService {
-
-    companion object {
-        private val logger = LoggerFactory.getLogger(BitBucketApiService::class.java)
-    }
 
     override fun getUsername(token: String?): String? {
         return propertiesConfiguration.bitbucketWorkspace
@@ -69,7 +64,8 @@ class BitBucketApiService(
                     cloneUrl.orEmpty(),
                     propertiesConfiguration.sourceType,
                     sourceInstance,
-                    bbRepo.name
+                    bbRepo.name,
+                    bbRepo.uuid
                 )
             )
         }

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/ExitScheduler.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/ExitScheduler.kt
@@ -40,7 +40,7 @@ class ExitScheduler(
                 " - Tasks submitted: $tasksSubmitted, Tasks completed: $tasksCompleted," +
                 " Tasks pending: $pendingTasks, Tasks active: $tasksActive"
         )
-        if (pendingTasks == 0L) {
+        if (VsmSbomBoosterApplication.gotRepositories && pendingTasks == 0L) {
             logger.info("Submitted ${VsmSbomBoosterApplication.counter.get()} services with SBOM file to VSM.")
             logger.info("You can find a detailed summary report inside the mounted folder.")
             summaryReportService.appendRecord(

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/ExitScheduler.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/ExitScheduler.kt
@@ -20,7 +20,7 @@ class ExitScheduler(
         private val logger: Logger = LoggerFactory.getLogger(ExitScheduler::class.java)
     }
 
-    @Scheduled(fixedRate = 100000, initialDelay = 30000)
+    @Scheduled(fixedRate = 100000, initialDelay = 600000)
     fun checkPendingTasks() {
         val tasksSubmitted = threadPoolTaskExecutor.threadPoolExecutor.taskCount
         val tasksCompleted = threadPoolTaskExecutor.threadPoolExecutor.completedTaskCount
@@ -40,7 +40,7 @@ class ExitScheduler(
                 " - Tasks submitted: $tasksSubmitted, Tasks completed: $tasksCompleted," +
                 " Tasks pending: $pendingTasks, Tasks active: $tasksActive"
         )
-        if (VsmSbomBoosterApplication.gotRepositories && pendingTasks == 0L) {
+        if (pendingTasks == 0L) {
             logger.info("Submitted ${VsmSbomBoosterApplication.counter.get()} services with SBOM file to VSM.")
             logger.info("You can find a detailed summary report inside the mounted folder.")
             summaryReportService.appendRecord(

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/GitHubApiService.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/GitHubApiService.kt
@@ -81,7 +81,8 @@ class GitHubApiService(
                                         it?.node?.url.toString(),
                                         propertiesConfiguration.sourceType,
                                         sourceInstance,
-                                        it?.node?.name.toString()
+                                        it?.node?.name.toString(),
+                                        it?.node?.id.toString()
                                     )
                                 )
                             }

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/GitLabApiService.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/GitLabApiService.kt
@@ -82,7 +82,8 @@ class GitLabApiService(
                                         it?.httpUrlToRepo ?: "",
                                         propertiesConfiguration.sourceType,
                                         sourceInstance,
-                                        it?.name.toString()
+                                        it?.name.toString(),
+                                        it?.id.toString(),
                                     )
                                 )
                             }

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/ProcessService.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/ProcessService.kt
@@ -31,18 +31,19 @@ class ProcessService(
     @Async
     fun processRepository(
         propertiesConfiguration: PropertiesConfiguration,
-        username: String?,
+        username: String,
+        token: String,
         repository: Repository
     ) {
         val startInstant = Instant.now()
         var downloadedFolder: String? = null
-        if (!username.isNullOrBlank()) {
+        if (username.isNotBlank()) {
             try {
                 logger.info("Beginning to download repository with url: ${repository.cloneUrl}")
                 downloadedFolder = ortService.downloadProject(
                     repository.cloneUrl,
                     username,
-                    propertiesConfiguration.githubToken
+                    token
                 )
                 logger.info(
                     "Finished downloading repository with url: ${repository.cloneUrl} to temp folder: $downloadedFolder"

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/ProcessService.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/ProcessService.kt
@@ -75,7 +75,8 @@ class ProcessService(
                         downloadedFolder,
                         repository.sourceType,
                         repository.sourceInstance,
-                        repository.name
+                        repository.name,
+                        repository.repoId
                     )
                 )
             } catch (e: Exception) {

--- a/src/main/kotlin/net/leanix/vsm/sbomBooster/service/VsmDiscoveryService.kt
+++ b/src/main/kotlin/net/leanix/vsm/sbomBooster/service/VsmDiscoveryService.kt
@@ -41,6 +41,7 @@ class VsmDiscoveryService(
         val multipartBodyBuilder = MultipartBodyBuilder()
 
         multipartBodyBuilder.part("id", discoveryItem.name)
+        multipartBodyBuilder.part("repoId", discoveryItem.repoId)
         multipartBodyBuilder.part("sourceType", discoveryItem.sourceType)
         multipartBodyBuilder.part("sourceInstance", discoveryItem.sourceInstance)
         multipartBodyBuilder.part("name", discoveryItem.name)

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -24,3 +24,8 @@ leanix:
     gitlab-api-host: ${GITLAB_API_HOST:gitlab.com}
     gitlab-token: ${GITLAB_TOKEN:}
     gitlab-group: ${GITLAB_GROUP:}
+
+    ## BITBUCKET
+    bitbucket-key: ${BITBUCKET_KEY:}
+    bitbucket-secret: ${BITBUCKET_SECRET:}
+    bitbucket-workspace: ${BITBUCKET_WORKSPACE:}

--- a/src/main/resources/queries/Github/GetRepositoriesPaginated.graphql
+++ b/src/main/resources/queries/Github/GetRepositoriesPaginated.graphql
@@ -5,6 +5,7 @@ query GetRepositoriesPaginated($login: String!, $first: Int!, $after: String){
                 edges {
                     cursor
                     node {
+                        id
                         url
                         name
                     }

--- a/src/main/resources/queries/Gitlab/GetRepositoriesPaginated.graphql
+++ b/src/main/resources/queries/Gitlab/GetRepositoriesPaginated.graphql
@@ -9,6 +9,7 @@ query GetRepositoriesPaginated($groupName: ID!, $first: Int, $after: String) {
                 httpUrlToRepo
                 fullPath
                 name
+                id
             }
         }
     }


### PR DESCRIPTION
Added support for Bitbucket cloud. Has been tested with a free trial account as well as a customer's Bitbucket Enterprise Workspace. 

You'll notice a new boolean stored in the VsmSbomBoosterApplication, which is referenced in the ExitScheduler. The customer had so many repositories, that the ExitScheduler would run before the scan was finished, see nothing was submitted to ORT yet, and kill the whole process. This boolean prevents the ExitScheduler from killing the application until at least one repository has been processed.