### PR TITLE
INVT-11619: Update snakeyaml to version 2.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,3 +69,4 @@ detekt {
 	}
 }
 
+ext["snakeyaml.version"] = "2.2"


### PR DESCRIPTION
This is a false positive as stated here https://github.com/spring-projects/spring-boot/issues/33457 and since we are not doing any manual yaml parsing. However, we can update to v2.2 to completely remove the snakeyaml 1.33 from our jars.