### PR TITLE
CID-1614: Automatic release notes, added pull request template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+  $CHANGES

--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -6,6 +6,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     runs-on: ubuntu-latest
 
@@ -17,8 +27,33 @@ jobs:
         uses: K-Phoen/semver-release-action@master
         with:
           release_branch: main
+          release_strategy: tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish Release Draft
+        uses: actions/github-script@v6.4.1
+        if: (steps.tag-action.outputs.tag != '')
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            const tag = "${{ steps.tag-action.outputs.tag }}";
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            const draftRelease = releases.find(release => release.tag_name === tag && release.draft === true);
+            if (!draftRelease) {
+              console.log(`No draft release found for tag ${tag}`);
+              return;
+            }
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: draftRelease.id,
+              draft: false
+            });
+            console.log(`Published draft release for tag ${tag}`);
 
       - name: Inject secret store credentials
         uses: leanix/secrets-action@master

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,26 @@
+## 🛠 Changes made
+Please explain here the changes you made in this PR.
+
+## ✨ Type of change
+Please delete the options that are not relevant.
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+## 🧪 How Has This Been Tested?
+Please describe the tests that you ran to verify your changes.
+
+- [ ] Test A
+- [ ] Test B
+- [ ] 👌 No tests required
+- [ ] 🚨 No tests Deployed
+
+## 🏎 Checklist:
+- [ ] My code follows the style guidelines
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] Any dependent changes have been merged and published in downstream modules
+- [ ] I have made corresponding changes to the documentation (README.md)
+- [ ] My commit message clearly reflects the changes made
+- [ ] Assigned the appropriate labels (version, PR type, etc.)


### PR DESCRIPTION
This PR includes two enhancements to the repository's workflow:

- The addition of a new Pull Request template.
- The introduction of a new tool, Release Drafter, which will automate the process of generating release notes.

**New Pull Request Template.**
The pull_request_template.md in the docs folder offers a structured and systematic way of recording changes made in PRs. This markdown file presents a list of possible changes, sections on the type of change, description of tests run, and a checklist for contributors to follow before submitting their PR. This will aid in providing more consistent and detailed PR reviews, hence improving collaboration.

**Release Drafter**
We will use Release Drafter to automate the creation of release notes (in a draft release). Once a PR is closed, Release Drafter automatically updates the release draft with details pulled from the PR.

The release-drafter.yml file, located in .github directory, holds the rules on how the release notes will be structured. Our configuration categorizes changes into features, bug fixes, and maintenance, each related to specific labels such as feature, fix, and chore respectively.

In addition, it determines the versioning rules: A 'major', 'minor', or 'patch' label attached to any PR will bump up the project's corresponding version.